### PR TITLE
[Feature] Resize profile image.

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "expo-facebook": "~8.0.0",
     "expo-font": "^8.0.0",
     "expo-google-sign-in": "~8.0.0",
+    "expo-image-manipulator": "^8.0.0",
     "expo-image-picker": "~8.0.2",
     "expo-linear-gradient": "~8.0.0",
     "expo-localization": "~8.0.0",

--- a/src/components/screen/ProfileUpdate.tsx
+++ b/src/components/screen/ProfileUpdate.tsx
@@ -1,6 +1,6 @@
 import { Button, EditText } from '@dooboo-ui/native';
 import { IC_CAMERA, IC_PROFILE } from '../../utils/Icons';
-import { Image, ImageResolvedAssetSource, ImageSourcePropType, TouchableOpacity, View } from 'react-native';
+import { Image, TouchableOpacity, View } from 'react-native';
 import React, { useEffect, useState } from 'react';
 import { launchCameraAsync, launchImageLibraryAsync } from '../../utils/ImagePicker';
 

--- a/src/components/screen/ProfileUpdate.tsx
+++ b/src/components/screen/ProfileUpdate.tsx
@@ -1,6 +1,6 @@
 import { Button, EditText } from '@dooboo-ui/native';
 import { IC_CAMERA, IC_PROFILE } from '../../utils/Icons';
-import { Image, TouchableOpacity, View } from 'react-native';
+import { Image, ImageResolvedAssetSource, ImageSourcePropType, TouchableOpacity, View } from 'react-native';
 import React, { useEffect, useState } from 'react';
 import { launchCameraAsync, launchImageLibraryAsync } from '../../utils/ImagePicker';
 
@@ -8,6 +8,7 @@ import { EditTextInputType } from '@dooboo-ui/native/lib/EditText';
 import { MainStackNavigationProps } from '../navigation/MainStackNavigator';
 import { encryptMessage } from '../../utils/virgil';
 import { getString } from '../../../STRINGS';
+import { resizeImage } from '../../utils/image';
 import styled from 'styled-components/native';
 import { useActionSheet } from '@expo/react-native-action-sheet';
 import { useThemeContext } from '@dooboo-ui/native-theme';
@@ -15,6 +16,10 @@ import { useThemeContext } from '@dooboo-ui/native-theme';
 const BUTTON_INDEX_LAUNCH_CAMERA = 0;
 const BUTTON_INDEX_LAUNCH_IMAGE_LIBLARY = 1;
 const BUTTON_INDEX_CANCEL = 2;
+const DEFAULT = {
+  PROFILEIMAGE_WIDTH: 300,
+  PROFILEIMAGE_HEIGHT: 300,
+};
 
 const Container = styled.View`
   flex: 1;
@@ -98,7 +103,7 @@ function Screen(props: Props): React.ReactElement {
     }
   };
 
-  const pressProfileImage = (): void => {
+  const pressProfileImage = async (): Promise<void> => {
     const options = [
       getString('TAKE_A_PICTURE'),
       getString('SELSCT_FROM_ALBUM'),
@@ -112,17 +117,29 @@ function Screen(props: Props): React.ReactElement {
       },
       async (buttonIndex: number) => {
         if (buttonIndex === BUTTON_INDEX_LAUNCH_CAMERA) {
-          const result = await launchCameraAsync();
-          if (result && !result.cancelled) {
-            setProfilePath(result.uri);
+          const image = await launchCameraAsync();
+          if (image && !image.cancelled) {
+            const resizedImage = await resizeImage({
+              imageUri: image.uri,
+              maxWidth: DEFAULT.PROFILEIMAGE_WIDTH,
+              maxHeight: DEFAULT.PROFILEIMAGE_HEIGHT,
+            });
+
+            setProfilePath(resizedImage.uri);
           }
           return;
         }
 
         if (buttonIndex === BUTTON_INDEX_LAUNCH_IMAGE_LIBLARY) {
-          const result = await launchImageLibraryAsync();
-          if (result && !result.cancelled) {
-            setProfilePath(result.uri);
+          const image = await launchImageLibraryAsync();
+          if (image && !image.cancelled) {
+            const resizedImage = await resizeImage({
+              imageUri: image.uri,
+              maxWidth: DEFAULT.PROFILEIMAGE_WIDTH,
+              maxHeight: DEFAULT.PROFILEIMAGE_HEIGHT,
+            });
+
+            setProfilePath(resizedImage.uri);
           }
         }
       },

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,0 +1,70 @@
+import * as ImageManipulator from 'expo-image-manipulator';
+
+import { Image } from 'react-native';
+
+const DEFAULT = {
+  IMAGE_WIDTH: 300,
+  IMAGE_HEIGHT: 300,
+};
+
+export interface ImageSize {
+  width: number;
+  height: number;
+}
+
+export const resizeImage = async ({
+  imageUri,
+  maxWidth,
+  maxHeight,
+}: {
+  imageUri: string;
+  maxWidth?: number;
+  maxHeight?: number;
+}): Promise<ImageManipulator.ImageResult> => {
+  const getOriginalSize = (imageUri: string): Promise<ImageSize> => new Promise<ImageSize>(
+    (resolve, reject) => Image.getSize(
+      imageUri,
+      (width: number, height: number) => resolve({
+        width,
+        height,
+      }),
+      reject,
+    ),
+  );
+
+  const manipulate = ({
+    width,
+    height,
+  }: {
+    width?: number;
+    height?: number;
+  }): Promise<ImageManipulator.ImageResult> => ImageManipulator.manipulateAsync(
+    imageUri,
+    [{ resize: { width, height } }],
+    { compress: 1, format: ImageManipulator.SaveFormat.PNG },
+  );
+
+  const { width: originWidth, height: originHeight } = await getOriginalSize(imageUri);
+
+  if (originWidth >= originHeight) {
+    if (maxWidth === undefined || maxWidth === null) {
+      return manipulate({ width: DEFAULT.IMAGE_WIDTH });
+    }
+
+    if (maxWidth !== undefined && originWidth < maxWidth) {
+      return manipulate({ width: originWidth });
+    }
+
+    return manipulate({ width: maxWidth });
+  }
+
+  if (maxHeight === undefined || maxHeight === null) {
+    return manipulate({ height: DEFAULT.IMAGE_HEIGHT });
+  }
+
+  if (originHeight < maxHeight) {
+    return manipulate({ height: originHeight });
+  }
+
+  return manipulate({ height: maxHeight });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5847,6 +5847,11 @@ expo-google-sign-in@~8.0.0:
   dependencies:
     invariant "^2.2.4"
 
+expo-image-manipulator@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/expo-image-manipulator/-/expo-image-manipulator-8.0.0.tgz#d7a8ba836a417f7fd1f07db5cde4eb7c0611d608"
+  integrity sha512-7KaQca4szyNllM30ZAnyL7ww83/YJFDl4Yr/4/WglXAKas96WOBztsF7/CPrboEVh/LzfqtSFW0PtyYgrC2o9Q==
+
 expo-image-picker@~8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/expo-image-picker/-/expo-image-picker-8.0.2.tgz#14139f1d73793ae7fba6fe3cf34e1dc91baf402a"


### PR DESCRIPTION
## Description
- Implemented resizing profile image.
  - with a utility to resize an image.
  - used [expo-image-manipulator](https://docs.expo.io/versions/latest/sdk/imagemanipulator/) to resize an image on Android and iOS

## Related Issues

- https://github.com/dooboolab/hackatalk-server/issues/52

## Tests

- No test yet.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk-mobile/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
